### PR TITLE
Fixed installation issue and improved UX.

### DIFF
--- a/mullvad-vpn-updater-deb.sh
+++ b/mullvad-vpn-updater-deb.sh
@@ -5,10 +5,10 @@
 #### Published on: https://github.com/poneli/
 #### =====================================================================
 #### <VARIABLES>
-latestversion=$(curl -s -L https://github.com/mullvad/mullvadvpn-app/releases/latest | grep -m1 "/mullvad/mullvadvpn-app/releases/tag/" | cut -d '/' -f 9 | cut -d '"' -f 1)
+latestversion=$(curl -s -L https://github.com/mullvad/mullvadvpn-app/releases/latest | grep -m1 "/mullvad/mullvadvpn-app/releases/tag/20*" | cut -d '/' -f 9 | cut -d '"' -f 1)
 currentversion=$(mullvad version | awk '/Current version:/ { print $3 }')
 package=$(curl -s -L https://github.com/mullvad/mullvadvpn-app/releases/latest | grep "/mullvad/mullvadvpn-app/releases/download/${latestversion}/" | grep -m1 amd64.deb | cut -d '"' -f2)
-downloadfolder="/change/me/example/directory" # No trailing slash
+downloadfolder="/home/(username)/Downloads" # No trailing slash
 #### </VARIABLES>
 if [[ $EUID -gt 0 ]]; then
 	printf "Run with sudo... \n"
@@ -17,17 +17,18 @@ fi
 
 if [[ $latestversion > $currentversion ]]; then
 	printf "Downloading mullvad-vpn to %s... \n" "$downloadfolder"
-	wget -q https://github.com$package -P $downloadfolder
+	wget https://github.com$package -P $downloadfolder
 	printf "Installing update... \n";
-	dpkg -i $downloadfolder/*.deb &>/dev/null
+	dpkg -i $downloadfolder/MullvadVPN*.deb &>/dev/null
 	if [[ $(mullvad version | awk '/Current version:/ { print $3 }') = $latestversion ]]; then
 	  printf "mullvad-vpn updated successfully from version %s to %s... \n" "$currentversion" "$latestversion"
 	  printf -- "%(%Y-%m-%d %H:%M)T [SUCCESS] mullvad-vpn updated to %s... \n" "$(date +%s)" "$latestversion" | tee -a $downloadfolder/update.log >/dev/null
 	  printf "Cleaning up %s... \n" "$downloadfolder"
-	  rm -f $downloadfolder/*.deb
+	  rm -f $downloadfolder/MullvadVPN*.deb
 	else
 	  printf "Installation of mullvad-vpn %s failed... \nTerminated... \n" "$latestversion"
 	  printf -- "%(%Y-%m-%d %H:%M)T [ERROR] mullvad-vpn %s update failed... \n" "$(date +%s)" "$latestversion" | tee -a $downloadfolder/update.log >/dev/null
+	  rm -f $downloadfolder/MullvadVPN*.deb
 	fi
 else
 	printf "mullvad-vpn %s is already installed... \nTerminated... \n" "$latestversion"

--- a/mullvad-vpn-updater-rpm.sh
+++ b/mullvad-vpn-updater-rpm.sh
@@ -5,10 +5,10 @@
 #### Published on: https://github.com/poneli/
 #### =====================================================================
 #### <VARIABLES>
-latestversion=$(curl -s -L https://github.com/mullvad/mullvadvpn-app/releases/latest | grep -m1 "/mullvad/mullvadvpn-app/releases/tag/" | cut -d '/' -f 9 | cut -d '"' -f 1)
+latestversion=$(curl -s -L https://github.com/mullvad/mullvadvpn-app/releases/latest | grep -m1 "/mullvad/mullvadvpn-app/releases/tag/20*" | cut -d '/' -f 9 | cut -d '"' -f 1)
 currentversion=$(mullvad version | awk '/Current version:/ { print $3 }')
 package=$(curl -s -L https://github.com/mullvad/mullvadvpn-app/releases/latest | grep "/mullvad/mullvadvpn-app/releases/download/$latestversion/" | grep -m1 .rpm | cut -d '"' -f2)
-downloadfolder="/change/me/example/directory" # No trailing slash
+downloadfolder="/home/(username)/Downloads" # No trailing slash
 #### </VARIABLES>
 if [[ $EUID -gt 0 ]]; then
 	printf "Run with sudo... \n"
@@ -17,19 +17,19 @@ fi
 
 if [[ $latestversion > $currentversion ]]; then
 	printf "Downloading mullvad-vpn to %s... \n" "$downloadfolder"
-	wget -q https://github.com$package -P $downloadfolder
+	wget https://github.com$package -P $downloadfolder
 	printf "Installing update... \n"
-	yum localinstall -y $downloadfolder/*.rpm &>/dev/null
+	dnf localinstall -y $downloadfolder/MullvadVPN*.rpm &>/dev/null
 	if [[ $(mullvad version | awk '/Current version:/ { print $3 }') = $latestversion ]]; then
 	  printf "mullvad-vpn updated successfully from version %s to %s... \n" "$currentversion" "$latestversion"
 	  printf -- "%(%Y-%m-%d %H:%M)T [SUCCESS] mullvad-vpn updated to %s... \n" "$(date +%s)" "$latestversion" | tee -a $downloadfolder/update.log >/dev/null
 	  printf "Cleaning up %s... \n" "$downloadfolder"
-	  rm -f $downloadfolder/*.rpm
+	  rm -f $downloadfolder/MullvadVPN*.rpm
 	else
 	  printf "Installation of mullvad-vpn %s failed... \nTerminated... \n" "$latestversion"
 	  printf -- "%(%Y-%m-%d %H:%M)T [ERROR] mullvad-vpn %s update failed... \n" "$(date +%s)" "$latestversion" | tee -a $downloadfolder/update.log >/dev/null
 	  printf "Cleaning up %s... \n" "$downloadfolder"
-	  rm -f $downloadfolder/*.rpm
+	  rm -f $downloadfolder/MullvadVPN*.rpm
 	fi
 else
 	printf "mullvad-vpn %s is already installed... \nTerminated... \n" "$latestversion"


### PR DESCRIPTION
I changed the default download dir to well, downloads. The user has to input their user name maybe a prompt can be added for that or it can be grabbed automatically somehow. I changed the rm line to remove only mullvadvpn files as to not destroy other rpms/debs. I changed wget back to verbose so the user knows what's going on and can tell if it's actually downloading. And I put a wildcard on the tag because the latest release on mullvad's repo was the android version which doesn't work on linux desktop. Luckily their releases for android start with "android" but, for desktop they start with the number. This naming scheme should work up until year 2099 or at least until mullvad stops with the naming scheme. Thanks for making this script it looks really cool.